### PR TITLE
v0.5.3

### DIFF
--- a/dist/witnet/toolkit.js
+++ b/dist/witnet/toolkit.js
@@ -67,7 +67,7 @@ var toolkitFileNames = {
     return "witnet_toolkit-".concat(arch, "-pc-windows-msvc.exe");
   },
   linux: function linux(arch) {
-    return "witnet_toolkit-".concat(arch, "-unknown-linux-gnu");
+    return "witnet_toolkit-".concat(arch, "-unknown-linux-gnu").concat(arch.includes("arm") ? "eabihf" : "");
   },
   darwin: function darwin(arch) {
     return "witnet_toolkit-".concat(arch, "-apple-darwin");

--- a/dist/witnet/toolkit.js
+++ b/dist/witnet/toolkit.js
@@ -61,7 +61,7 @@ var _require2 = require("child_process"),
  */
 
 
-var toolkitDownloadUrlBase = "https://github.com/witnet/witnet-rust/releases/download/1.3.0/";
+var toolkitDownloadUrlBase = "https://github.com/witnet/witnet-rust/releases/download/1.3.1/";
 var toolkitFileNames = {
   win32: function win32(arch) {
     return "witnet_toolkit-".concat(arch, "-pc-windows-msvc.exe");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "witnet-requests",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Witnet Requests Lib",
   "main": "dist/index.js",
   "repository": "https://github.com/witnet/witnet-requests-js",

--- a/src/witnet/toolkit.js
+++ b/src/witnet/toolkit.js
@@ -18,7 +18,7 @@ const { exec } = require("child_process")
 /*
  Constants
  */
-const toolkitDownloadUrlBase = "https://github.com/witnet/witnet-rust/releases/download/1.3.0/"
+const toolkitDownloadUrlBase = "https://github.com/witnet/witnet-rust/releases/download/1.3.1/"
 const toolkitFileNames = {
   win32: (arch) => `witnet_toolkit-${arch}-pc-windows-msvc.exe`,
   linux: (arch) => `witnet_toolkit-${arch}-unknown-linux-gnu`,

--- a/src/witnet/toolkit.js
+++ b/src/witnet/toolkit.js
@@ -21,7 +21,7 @@ const { exec } = require("child_process")
 const toolkitDownloadUrlBase = "https://github.com/witnet/witnet-rust/releases/download/1.3.1/"
 const toolkitFileNames = {
   win32: (arch) => `witnet_toolkit-${arch}-pc-windows-msvc.exe`,
-  linux: (arch) => `witnet_toolkit-${arch}-unknown-linux-gnu`,
+  linux: (arch) => `witnet_toolkit-${arch}-unknown-linux-gnu${arch.includes("arm") ? "eabihf" : ""}`,
   darwin: (arch) => `witnet_toolkit-${arch}-apple-darwin`,
 }
 const archsMap = {


### PR DESCRIPTION
- Use the latest binary for `witnet_toolkit`
- Adds compatibility with arm6 and arm7 architectures
- Bumps package version to 0.5.3