### PR TITLE
Initial support for HTTP POST and StringParseXmlMap

### DIFF
--- a/assets/witnet.proto
+++ b/assets/witnet.proto
@@ -120,6 +120,7 @@ message DataRequestOutput {
             Unknown = 0;
             HttpGet = 1;
             Rng = 2;
+            HttpPost = 3;
         }
         message RADFilter {
             uint32 op = 1;
@@ -130,6 +131,10 @@ message DataRequestOutput {
             string url = 2;
             // TODO: RADScript should maybe be a type?
             bytes script = 3;
+            // Body of HTTP-POST request
+            bytes body = 4;
+            // Extra headers for HTTP-GET and HTTP-POST requests
+            repeated StringPair headers = 5;
         }
         message RADAggregate {
             repeated RADFilter filters = 1;
@@ -152,6 +157,11 @@ message DataRequestOutput {
     uint64 commit_and_reveal_fee = 4;
     uint32 min_consensus_percentage = 5;
     uint64 collateral = 6;
+}
+
+message StringPair {
+    string left = 1;
+    string right = 2;
 }
 
 message Input {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29,6 +29,12 @@ Object.defineProperty(exports, "Source", {
     return _stages.HttpGetSource;
   }
 });
+Object.defineProperty(exports, "HttpPostSource", {
+  enumerable: true,
+  get: function get() {
+    return _stages.HttpPostSource;
+  }
+});
 Object.defineProperty(exports, "RandomSource", {
   enumerable: true,
   get: function get() {

--- a/dist/radon/types.js
+++ b/dist/radon/types.js
@@ -154,7 +154,8 @@ var typeSystem = (_typeSystem = {}, _defineProperty(_typeSystem, TYPES.ANY, {
 exports.typeSystem = typeSystem;
 var RETRIEVAL_METHODS = {
   HttpGet: 0x01,
-  Rng: 0x02
+  Rng: 0x02,
+  HttpPost: 0x02
 }; // Helper function that helps pretty-printing RADON types
 
 exports.RETRIEVAL_METHODS = RETRIEVAL_METHODS;

--- a/dist/radon/types.js
+++ b/dist/radon/types.js
@@ -147,7 +147,7 @@ var typeSystem = (_typeSystem = {}, _defineProperty(_typeSystem, TYPES.ANY, {
   match: [0x75, [PSEUDOTYPES.MATCH]],
   parseJSONArray: [0x76, [TYPES.ARRAY]],
   parseJSONMap: [0x77, [TYPES.MAP]],
-  //parseXML: [0x78, [TYPES.MAP]],
+  parseXMLMap: [0x78, [TYPES.MAP]],
   toLowerCase: [0x79, [TYPES.STRING]],
   toUpperCase: [0x7A, [TYPES.STRING]]
 }), _typeSystem);

--- a/dist/witnet/stages.js
+++ b/dist/witnet/stages.js
@@ -5,7 +5,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "functi
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Tally = exports.RandomSource = exports.HttpGetSource = exports.Aggregator = void 0;
+exports.Tally = exports.RandomSource = exports.HttpPostSource = exports.HttpGetSource = exports.Aggregator = void 0;
 
 var CBOR = _interopRequireWildcard(require("cbor"));
 
@@ -87,15 +87,35 @@ var HttpGetSource = /*#__PURE__*/function (_Source) {
 
 exports.HttpGetSource = HttpGetSource;
 
-var RandomSource = /*#__PURE__*/function (_Source2) {
-  _inherits(RandomSource, _Source2);
+var HttpPostSource = /*#__PURE__*/function (_Source2) {
+  _inherits(HttpPostSource, _Source2);
 
-  var _super3 = _createSuper(RandomSource);
+  var _super3 = _createSuper(HttpPostSource);
+
+  function HttpPostSource(url) {
+    var _this3;
+
+    _classCallCheck(this, HttpPostSource);
+
+    _this3 = _super3.call(this, _types.RETRIEVAL_METHODS.HttpPost, [_types.TYPES.STRING]);
+    _this3.url = url;
+    return _this3;
+  }
+
+  return HttpPostSource;
+}(Source);
+
+exports.HttpPostSource = HttpPostSource;
+
+var RandomSource = /*#__PURE__*/function (_Source3) {
+  _inherits(RandomSource, _Source3);
+
+  var _super4 = _createSuper(RandomSource);
 
   function RandomSource() {
     _classCallCheck(this, RandomSource);
 
-    return _super3.call(this, _types.RETRIEVAL_METHODS.Rng, [_types.TYPES.BYTES]);
+    return _super4.call(this, _types.RETRIEVAL_METHODS.Rng, [_types.TYPES.BYTES]);
   }
 
   return RandomSource;
@@ -138,7 +158,7 @@ var Joiner = /*#__PURE__*/function () {
 var Aggregator = /*#__PURE__*/function (_Joiner) {
   _inherits(Aggregator, _Joiner);
 
-  var _super4 = _createSuper(Aggregator);
+  var _super5 = _createSuper(Aggregator);
 
   function Aggregator(_ref3) {
     var _ref3$filters = _ref3.filters,
@@ -147,7 +167,7 @@ var Aggregator = /*#__PURE__*/function (_Joiner) {
 
     _classCallCheck(this, Aggregator);
 
-    return _super4.call(this, filters, reducer);
+    return _super5.call(this, filters, reducer);
   }
 
   return Aggregator;
@@ -158,7 +178,7 @@ exports.Aggregator = Aggregator;
 var Tally = /*#__PURE__*/function (_Joiner2) {
   _inherits(Tally, _Joiner2);
 
-  var _super5 = _createSuper(Tally);
+  var _super6 = _createSuper(Tally);
 
   function Tally(_ref4) {
     var _ref4$filters = _ref4.filters,
@@ -167,7 +187,7 @@ var Tally = /*#__PURE__*/function (_Joiner2) {
 
     _classCallCheck(this, Tally);
 
-    return _super5.call(this, filters, reducer);
+    return _super6.call(this, filters, reducer);
   }
 
   return Tally;

--- a/dist/witnet/toolkit.js
+++ b/dist/witnet/toolkit.js
@@ -343,16 +343,24 @@ function decodeScriptsAndArguments(mir) {
     });
   });
   decoded.aggregate.filters = decoded.aggregate.filters.map(function (filter) {
-    var decodedArgs = cbor.decode(Buffer.from(filter.args));
-    return _objectSpread(_objectSpread({}, filter), {}, {
-      args: decodedArgs
-    });
+    if (filter.args.length > 0) {
+      var decodedArgs = cbor.decode(Buffer.from(filter.args));
+      return _objectSpread(_objectSpread({}, filter), {}, {
+        args: decodedArgs
+      });
+    } else {
+      return filter;
+    }
   });
   decoded.tally.filters = decoded.tally.filters.map(function (filter) {
-    var decodedArgs = cbor.decode(Buffer.from(filter.args));
-    return _objectSpread(_objectSpread({}, filter), {}, {
-      args: decodedArgs
-    });
+    if (filter.args.length > 0) {
+      var decodedArgs = cbor.decode(Buffer.from(filter.args));
+      return _objectSpread(_objectSpread({}, filter), {}, {
+        args: decodedArgs
+      });
+    } else {
+      return filter;
+    }
   });
   return decoded;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { Script } from "./radon/script"
-import { Aggregator, HttpGetSource, RandomSource, Tally } from "./witnet/stages"
+import { Aggregator, HttpGetSource, HttpPostSource, RandomSource, Tally } from "./witnet/stages"
 import { Request } from "./witnet/request"
 import * as Types from "./radon/types"
 import * as Ethereum from "./ethereum"
@@ -10,6 +10,7 @@ export {
   Aggregator,
   Ethereum,
   HttpGetSource,
+  HttpPostSource,
   RandomSource,
   Request,
   Script,

--- a/src/radon/types.js
+++ b/src/radon/types.js
@@ -143,7 +143,7 @@ const typeSystem = {
     match: [0x75, [PSEUDOTYPES.MATCH]],
     parseJSONArray: [0x76, [TYPES.ARRAY]],
     parseJSONMap: [0x77, [TYPES.MAP]],
-    //parseXML: [0x78, [TYPES.MAP]],
+    parseXMLMap: [0x78, [TYPES.MAP]],
     toLowerCase: [0x79, [TYPES.STRING]],
     toUpperCase: [0x7A, [TYPES.STRING]],
   }

--- a/src/radon/types.js
+++ b/src/radon/types.js
@@ -152,6 +152,7 @@ const typeSystem = {
 const RETRIEVAL_METHODS = {
   HttpGet: 0x01,
   Rng: 0x02,
+  HttpPost: 0x02,
 }
 
 // Helper function that helps pretty-printing RADON types

--- a/src/witnet/stages.js
+++ b/src/witnet/stages.js
@@ -16,6 +16,13 @@ class HttpGetSource extends Source {
   }
 }
 
+class HttpPostSource extends Source {
+  constructor (url) {
+    super(RETRIEVAL_METHODS.HttpPost, [TYPES.STRING]);
+    this.url = url
+  }
+}
+
 class RandomSource extends Source {
   constructor () {
     super(RETRIEVAL_METHODS.Rng, [TYPES.BYTES]);
@@ -55,6 +62,7 @@ class Tally extends Joiner {
 export {
   Aggregator,
   HttpGetSource,
+  HttpPostSource,
   RandomSource,
   Tally,
 }

--- a/src/witnet/toolkit.js
+++ b/src/witnet/toolkit.js
@@ -205,12 +205,20 @@ function decodeScriptsAndArguments (mir) {
     return {...source, script: decodedScript}
   })
   decoded.aggregate.filters = decoded.aggregate.filters.map((filter) => {
-    const decodedArgs = cbor.decode(Buffer.from(filter.args))
-    return {...filter, args: decodedArgs}
+    if (filter.args.length > 0) {
+      const decodedArgs = cbor.decode(Buffer.from(filter.args))
+      return {...filter, args: decodedArgs}
+    } else {
+      return filter
+    }
   })
   decoded.tally.filters = decoded.tally.filters.map((filter) => {
-    const decodedArgs = cbor.decode(Buffer.from(filter.args))
-    return {...filter, args: decodedArgs}
+    if (filter.args.length > 0) {
+      const decodedArgs = cbor.decode(Buffer.from(filter.args))
+      return {...filter, args: decodedArgs}
+    } else {
+      return filter
+    }
   })
 
   return decoded


### PR DESCRIPTION
This is blocked by https://github.com/witnet/witnet-rust/pull/2188, and it will need to update the witnet_toolkit version from 1.4.3 to 1.5.2, but 1.5.2 is not released yet.

Also, fix #57 

Missing:

* HttpPost requests do not show the request body
* HttpGet and HttpPost requests do not show the request headers
* StringParseXmlMap operator doesn't work, it probably needs to be implemented in witnet-radon-js

For testing, you can use the following requests


HttpPost
```
0a950408c3a4f0ee0512350801122468747470733a2f2f7777772e6269747374616d702e6e65742f6170692f7469636b65722f1a0b821877821864646c61737412560801123168747470733a2f2f6170692e636f696e6465736b2e636f6d2f76312f6270692f63757272656e7470726963652e6a736f6e1a1f84187782186663627069821866635553448218646a726174655f666c6f617412f5020803121f68747470733a2f2f6170692e626c6f636b7461702e696f2f6772617068716c1a338718778218666464617461821861676d61726b65747382181800821866667469636b6572821867696c6173745072696365187222f8017b227175657279223a227175657279207072696365207b5c6e20206d61726b6574732866696c7465723a7b206261736553796d626f6c3a207b5f65713a5c224254435c227d2071756f746553796d626f6c3a207b5f696e3a5b5c225553445c222c5c22555344545c225d7d206d61726b65745374617475733a207b205f65713a20416374697665207d7d29207b5c6e202020206d61726b657453796d626f6c5c6e202020207469636b6572207b5c6e2020202020206c61737450726963655c6e202020207d5c6e20207d5c6e7d222c227661726961626c6573223a6e756c6c2c226f7065726174696f6e4e616d65223a227072696365227d2a200a0c436f6e74656e742d5479706512106170706c69636174696f6e2f6a736f6e1a0210032202100310e807180520642833308094ebdc03
```

StringParseXmlMap
```
0ad20112c3010801125f68747470733a2f2f666f7265636173742e776561746865722e676f762f4d6170436c69636b2e7068703f6c61743d33392e3735266c6f6e3d2d3130342e393926756e69743d30266c673d656e676c6973682646637374547970653d64776d6c1a5e8918788218666464776d6c8218616464617461821818008218666a706172616d6574657273821866677765617468657282186172776561746865722d636f6e646974696f6e73821818028218677040776561746865722d73756d6d6172791a02100222060a020808100210e807180f20642833308094ebdc03
```