### PR TITLE
fix: move necessary devDeps into deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,10 @@
     "build": "babel src -d dist",
     "compile": "npm run build"
   },
-  "devDependencies": {
+  "dependencies": {
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
-    "@babel/preset-env": "^7.15.0"
-  },
-  "dependencies": {
+    "@babel/preset-env": "^7.15.0",
     "cbor": "^8.0.0",
     "core-js": "^3.16.2",
     "protocol-buffers": "^4.1.0",


### PR DESCRIPTION
All the devDependencies in this package were used in runtime. That led to an error when someone tried to compile and didn't have installed the dependencies in their package.json