### PR TITLE
Add support for HTTP-POST, GraphQL sources, XML parsing and headers in HTTP-GET for rad2sol and toolkit

### DIFF
--- a/assets/witnet.proto
+++ b/assets/witnet.proto
@@ -120,6 +120,7 @@ message DataRequestOutput {
             Unknown = 0;
             HttpGet = 1;
             Rng = 2;
+            HttpPost = 3;
         }
         message RADFilter {
             uint32 op = 1;
@@ -130,6 +131,10 @@ message DataRequestOutput {
             string url = 2;
             // TODO: RADScript should maybe be a type?
             bytes script = 3;
+            // Body of HTTP-POST request
+            bytes body = 4;
+            // Extra headers for HTTP-GET and HTTP-POST requests
+            repeated StringPair headers = 5;
         }
         message RADAggregate {
             repeated RADFilter filters = 1;
@@ -152,6 +157,11 @@ message DataRequestOutput {
     uint64 commit_and_reveal_fee = 4;
     uint32 min_consensus_percentage = 5;
     uint64 collateral = 6;
+}
+
+message StringPair {
+    string left = 1;
+    string right = 2;
 }
 
 message Input {

--- a/src/ethereum/truffle/steps.js
+++ b/src/ethereum/truffle/steps.js
@@ -2,7 +2,7 @@ import * as Witnet from "../../..";
 import * as Babel from "@babel/core/lib/transform";
 import ProtoBuf from "protocol-buffers"
 
-const witnetAddresses = require(`${process.cwd()}/node_modules/witnet-solidity-bridge/migrations/witnet.addresses.json`)
+const witnetAddresses = require(`${process.cwd()}/node_modules/witnet-solidity-bridge/migrations/witnet.addresses`)
 const witnetSettings = require(`${process.cwd()}/node_modules/witnet-solidity-bridge/migrations/witnet.settings`)
 
 function isRoutedRequest (request) {
@@ -159,7 +159,7 @@ contract ${contractName}Request is WitnetRequestInitializableBase {
 `
 }
 
-export function writeRequestsList(newRequests, migrationsDir, fs) { 
+export function writeRequestsList(newRequests, migrationsDir, fs) {
   let existingRequests = {}
   const listFilePath = `${migrationsDir}witnet.requests.json`
   if (fs.existsSync(listFilePath)) {
@@ -174,7 +174,7 @@ export function writeRequestsList(newRequests, migrationsDir, fs) {
           newRequests[key] = { ...validExistingRequestsFields, ...newRequests[key] }
         } else {
           newRequests[key] = { ...existingRequests[key], ...newRequests[key] }
-        } 
+        }
       }
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { Script } from "./radon/script"
-import { Aggregator, HttpGetSource, RandomSource, Tally } from "./witnet/stages"
+import { Aggregator, HttpGetSource, HttpPostSource, RandomSource, Tally } from "./witnet/stages"
 import { Request } from "./witnet/request"
 import * as Types from "./radon/types"
 import * as Ethereum from "./ethereum"
@@ -10,6 +10,7 @@ export {
   Aggregator,
   Ethereum,
   HttpGetSource,
+  HttpPostSource,
   RandomSource,
   Request,
   Script,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { Script } from "./radon/script"
-import { Aggregator, HttpGetSource, HttpPostSource, RandomSource, Tally } from "./witnet/stages"
+import { Aggregator, GraphQLSource, HttpGetSource, HttpPostSource, RandomSource, Tally } from "./witnet/stages"
 import { Request } from "./witnet/request"
 import * as Types from "./radon/types"
 import * as Ethereum from "./ethereum"
@@ -9,6 +9,7 @@ const TYPES = Types.TYPES;
 export {
   Aggregator,
   Ethereum,
+  GraphQLSource,
   HttpGetSource,
   HttpPostSource,
   RandomSource,

--- a/src/radon/types.js
+++ b/src/radon/types.js
@@ -143,7 +143,7 @@ const typeSystem = {
     match: [0x75, [PSEUDOTYPES.MATCH]],
     parseJSONArray: [0x76, [TYPES.ARRAY]],
     parseJSONMap: [0x77, [TYPES.MAP]],
-    //parseXML: [0x78, [TYPES.MAP]],
+    parseXMLMap: [0x78, [TYPES.MAP]],
     toLowerCase: [0x79, [TYPES.STRING]],
     toUpperCase: [0x7A, [TYPES.STRING]],
   }

--- a/src/radon/types.js
+++ b/src/radon/types.js
@@ -152,7 +152,7 @@ const typeSystem = {
 const RETRIEVAL_METHODS = {
   HttpGet: 0x01,
   Rng: 0x02,
-  HttpPost: 0x02,
+  HttpPost: 0x03,
 }
 
 // Helper function that helps pretty-printing RADON types

--- a/src/radon/types.js
+++ b/src/radon/types.js
@@ -152,6 +152,7 @@ const typeSystem = {
 const RETRIEVAL_METHODS = {
   HttpGet: 0x01,
   Rng: 0x02,
+  HttpPost: 0x02,
 }
 
 // Helper function that helps pretty-printing RADON types

--- a/src/witnet/stages.js
+++ b/src/witnet/stages.js
@@ -5,21 +5,30 @@ import { RETRIEVAL_METHODS, TYPES } from "../radon/types"
 class Source extends Script {
   constructor(kind, firstType) {
     super(firstType);
-    this.kind = kind
+    this.kind = kind;
   }
 }
 
 class HttpGetSource extends Source {
-  constructor (url) {
+  constructor (url, headers) {
     super(RETRIEVAL_METHODS.HttpGet, [TYPES.STRING]);
-    this.url = url
+    this.url = url;
+    this.headers = headers && Object.entries(headers).map(([key, value]) => ({ left: key, right: value }));
   }
 }
 
 class HttpPostSource extends Source {
-  constructor (url) {
+  constructor (url, body, headers) {
     super(RETRIEVAL_METHODS.HttpPost, [TYPES.STRING]);
-    this.url = url
+    this.url = url;
+    this.body = body;
+    this.headers = headers && Object.entries(headers).map(([key, value]) => ({ left: key, right: value }));
+  }
+}
+
+class GraphQLSource extends HttpPostSource {
+  constructor (url, query, headers) {
+    super(url, JSON.stringify({ query }), headers);
   }
 }
 
@@ -61,8 +70,9 @@ class Tally extends Joiner {
 
 export {
   Aggregator,
+  GraphQLSource,
   HttpGetSource,
   HttpPostSource,
   RandomSource,
   Tally,
-}
+};

--- a/src/witnet/stages.js
+++ b/src/witnet/stages.js
@@ -16,6 +16,13 @@ class HttpGetSource extends Source {
   }
 }
 
+class HttpPostSource extends Source {
+  constructor (url) {
+    super(RETRIEVAL_METHODS.HttpPost, [TYPES.STRING]);
+    this.url = url
+  }
+}
+
 class RandomSource extends Source {
   constructor () {
     super(RETRIEVAL_METHODS.Rng, [TYPES.BYTES]);
@@ -55,6 +62,7 @@ class Tally extends Joiner {
 export {
   Aggregator,
   HttpGetSource,
+  HttpPostSource,
   RandomSource,
   Tally,
 }

--- a/src/witnet/toolkit.js
+++ b/src/witnet/toolkit.js
@@ -297,9 +297,25 @@ async function tryDataRequestCommand (settings, args) {
         traceInterpolation = ` |   ${sideChar}  ${red('[ERROR] Cannot decode execution trace information')}`
       }
 
-      const urlInterpolation = request ? `
+      let urlInterpolation = request ? `
  |   ${sideChar}  Method: ${radon.retrieve[sourceIndex].kind}
  |   ${sideChar}  Complete URL: ${radon.retrieve[sourceIndex].url}` : ''
+
+      // TODO: take headers info from `radon` instead of `request` once POST is supported in `witnet-radon-js`
+      const headers = request.retrieve[sourceIndex].headers
+      if (headers) {
+        const headersInterpolation = headers.map(([key, value]) => `
+ |   ${sideChar}    "${key}": "${value}"`).join()
+        urlInterpolation += `
+ |   ${sideChar}  Headers: ${headersInterpolation}`
+      }
+
+      // TODO: take body info from `radon` instead of `request` once POST is supported in `witnet-radon-js`
+      const body = request.retrieve[sourceIndex].body
+      if (body) {
+        urlInterpolation += `
+ |   ${sideChar}  Body: ${Buffer.from(body)}`
+      }
 
       const formattedRadonResult = formatRadonValue(source.result)
       const resultInterpolation = `${yellow(formattedRadonResult[0])}: ${formattedRadonResult[1]}`

--- a/src/witnet/toolkit.js
+++ b/src/witnet/toolkit.js
@@ -205,12 +205,20 @@ function decodeScriptsAndArguments (mir) {
     return {...source, script: decodedScript}
   })
   decoded.aggregate.filters = decoded.aggregate.filters.map((filter) => {
-    const decodedArgs = cbor.decode(Buffer.from(filter.args))
-    return {...filter, args: decodedArgs}
+    if (filter.args.length > 0) {
+      const decodedArgs = cbor.decode(Buffer.from(filter.args))
+      return {...filter, args: decodedArgs}
+    } else {
+      return filter
+    }
   })
   decoded.tally.filters = decoded.tally.filters.map((filter) => {
-    const decodedArgs = cbor.decode(Buffer.from(filter.args))
-    return {...filter, args: decodedArgs}
+    if (filter.args.length > 0) {
+      const decodedArgs = cbor.decode(Buffer.from(filter.args))
+      return {...filter, args: decodedArgs}
+    } else {
+      return filter
+    }
   })
 
   return decoded

--- a/src/witnet/toolkit.js
+++ b/src/witnet/toolkit.js
@@ -198,28 +198,25 @@ async function updateCommand (settings) {
     })
 }
 
+function decodeFilters (mir) {
+  return mir.map((filter) => {
+    if (filter.args.length > 0) {
+      const decodedArgs = cbor.decode(Buffer.from(filter.args))
+      return {...filter, args: decodedArgs}
+    } else {
+      return filter
+    }
+  })
+}
+
 function decodeScriptsAndArguments (mir) {
   let decoded = mir.data_request
   decoded.retrieve = decoded.retrieve.map((source) => {
     const decodedScript = cbor.decode(Buffer.from(source.script))
     return {...source, script: decodedScript}
   })
-  decoded.aggregate.filters = decoded.aggregate.filters.map((filter) => {
-    if (filter.args.length > 0) {
-      const decodedArgs = cbor.decode(Buffer.from(filter.args))
-      return {...filter, args: decodedArgs}
-    } else {
-      return filter
-    }
-  })
-  decoded.tally.filters = decoded.tally.filters.map((filter) => {
-    if (filter.args.length > 0) {
-      const decodedArgs = cbor.decode(Buffer.from(filter.args))
-      return {...filter, args: decodedArgs}
-    } else {
-      return filter
-    }
-  })
+  decoded.aggregate.filters = decodeFilters(decoded.aggregate.filters)
+  decoded.tally.filters = decodeFilters(decoded.tally.filters)
 
   return decoded
 }


### PR DESCRIPTION
- Add support for HTTP-POST in rad2sol
- Add support for headers in HTTP-GET in rad2sol
- Add support for all of the above in witnet-toolkit

Supersedes #58 
Related to https://github.com/witnet/witnet-rust/issues/2186