### PR TITLE
feat(radon): provide some off-the-shelf aggregator and tally functions

### DIFF
--- a/src/ethereum/truffle/rad2sol.js
+++ b/src/ethereum/truffle/rad2sol.js
@@ -10,6 +10,8 @@ const {
   requestsBanner, requestsSucceed, writeMigrations, writeSol
 } = require("../../../dist/ethereum/truffle/steps");
 
+const verbose = process.argv.includes('--verbose')
+
 const requestsDir = "./requests/";
 const requestContractsDir = "./contracts/requests/";
 const userContractsDir = "./contracts/";
@@ -58,4 +60,4 @@ Promise.all(steps.reduce(
     .then(() => writeMigrations(contractNames, userContractsDir, migrationsDir, { generateUserContractsMigrations, generateWitnetMigrations }, fs))
     .then(() => { if (generateRequestsList) { writeRequestsList(requestsList, migrationsDir, fs) } })
     .then(() => { if (generateUserContractsMigrations || generateWitnetMigrations) { migrationsSucceed() } })
-    .catch(fail);
+    .catch((error) => fail(error, process, verbose));

--- a/src/ethereum/truffle/steps.js
+++ b/src/ethereum/truffle/steps.js
@@ -42,12 +42,16 @@ export function migrationsSucceed () {
 `)
 }
 
-export function fail (error) {
+export function fail (error, process, verbose) {
+  process.exitCode = 1;
+
   console.error(`
 ! \x1b[31mWITNET REQUESTS COMPILATION ERRORS:\x1b[0m
-  - ${error.message}`);
-  process.exitCode = 1;
-  throw error
+- ${error.message}`);
+
+  if (verbose) {
+    throw error
+  }
 }
 
 export function readFile (path, fs) {

--- a/src/witnet/request.js
+++ b/src/witnet/request.js
@@ -1,3 +1,5 @@
+import {FILTERS, REDUCERS} from "../radon/types";
+
 class Request {
   constructor () {
     this.data = {
@@ -21,12 +23,47 @@ class Request {
     return this
   }
   setAggregator (aggregator) {
-    this.data.data_request.aggregate = aggregator || this.data.data_request.aggregate;
+    if (aggregator instanceof Function) aggregator = aggregator();
+
+    // Reject unsupported reducers
+    if (!(Object.values(REDUCERS).includes(aggregator.reducer))) {
+      throw Error(`Aggregator error. Reducer ${aggregator.reducer} is not supported. Please choose one of: ${["", ...Object.keys(REDUCERS)].join(`\n    - Witnet.Types.REDUCERS.`)}`)
+    }
+
+    for (let [index, filter] of aggregator.filters.entries()) {
+      // Sanitize malformed filters
+      if (!(Array.isArray(filter))) {
+        filter = aggregator.filters[index] = [filter]
+      }
+      // Reject unsupported filters
+      if (!(Object.values(FILTERS).includes(filter[0]))) {
+        throw Error(`Aggregator error. Filter ${filter[0]} is not supported. Please choose one of: ${["", ...Object.keys(FILTERS)].join(`\n    - Witnet.Types.FILTERS.`)}`)
+      }
+    }
+
+    this.data.data_request.aggregate = aggregator;
 
     return this
   }
   setTally (tally) {
-    this.data.data_request.tally = tally || this.data.data_request.tally;
+    if (tally instanceof Function) tally = tally();
+
+    // Reject unsupported reducers
+    if (!(Object.values(REDUCERS).includes(tally.reducer))) {
+      throw Error(`Tally error. Reducer ${tally.reducer} is not supported. Please choose one of: ${["", ...Object.keys(REDUCERS)].join(`\n    - Witnet.Types.REDUCERS.`)}`)
+    }
+
+    for (let [index, filter] of tally.filters.entries()) {
+      // Sanitize malformed filters
+      if (!(Array.isArray(filter))) {
+        filter = tally.filters[index] = [filter]
+      }
+      // Reject unsupported filters
+      if (!(Object.values(FILTERS).includes(filter[0]))) {
+        throw Error(`Tally error. Filter ${filter[0]} is not supported. Please choose one of: ${["", ...Object.keys(FILTERS)].join(`\n    - Witnet.Types.FILTERS.`)}`)
+      }
+    }
+    this.data.data_request.tally = tally;
 
     return this
   }

--- a/src/witnet/stages.js
+++ b/src/witnet/stages.js
@@ -1,6 +1,6 @@
 import * as CBOR from "cbor"
 import { Script } from ".."
-import { RETRIEVAL_METHODS, TYPES } from "../radon/types"
+import { FILTERS, REDUCERS, RETRIEVAL_METHODS, TYPES } from "../radon/types"
 
 class Source extends Script {
   constructor(kind, firstType) {
@@ -54,17 +54,61 @@ class Joiner {
       reducer: this.reducer,
     }
   }
+
+  static deviationAndAverage (deviation) {
+    return new Joiner([[FILTERS.deviationStandard, deviation]], REDUCERS.averageMean)
+  }
+
+  static deviationAndMedian (deviation) {
+    return new Joiner([[FILTERS.deviationStandard, deviation]], REDUCERS.averageMedian)
+  }
+
+  static mode () {
+    return new Joiner([[FILTERS.mode]], REDUCERS.mode)
+  }
 }
 
 class Aggregator extends Joiner {
-  constructor ({ filters = [], reducer }) {
+  constructor (filters, reducer) {
+    if (typeof filters === "object") {
+      reducer = filters["reducer"]
+      filters = filters["filters"]
+    }
     super(filters, reducer);
+  }
+
+  static default () {
+    return Aggregator.deviationAndAverage()
+  }
+
+  static deviationAndAverage (deviation = 1.5) {
+    return super.deviationAndAverage(deviation)
+  }
+
+  static deviationAndMedian (deviation = 1.5) {
+    return super.deviationAndMedian(deviation)
   }
 }
 
 class Tally extends Joiner {
-  constructor ({ filters = [], reducer }) {
+  constructor (filters, reducer) {
+    if (typeof filters === "object") {
+      reducer = filters["reducer"]
+      filters = filters["filters"]
+    }
     super(filters, reducer);
+  }
+
+  static default () {
+    return Tally.deviationAndAverage()
+  }
+
+  static deviationAndAverage (deviation = 2.5) {
+    return super.deviationAndAverage(deviation)
+  }
+
+  static deviationAndMedian (deviation = 2.5) {
+    return super.deviationAndMedian(deviation)
   }
 }
 

--- a/src/witnet/stages.js
+++ b/src/witnet/stages.js
@@ -55,7 +55,7 @@ class Joiner {
     }
   }
 
-  static deviationAndAverage (deviation) {
+  static deviationAndMean (deviation) {
     return new Joiner([[FILTERS.deviationStandard, deviation]], REDUCERS.averageMean)
   }
 
@@ -78,11 +78,11 @@ class Aggregator extends Joiner {
   }
 
   static default () {
-    return Aggregator.deviationAndAverage()
+    return Aggregator.deviationAndMean()
   }
 
-  static deviationAndAverage (deviation = 1.5) {
-    return super.deviationAndAverage(deviation)
+  static deviationAndMean (deviation = 1.5) {
+    return super.deviationAndMean(deviation)
   }
 
   static deviationAndMedian (deviation = 1.5) {
@@ -100,11 +100,11 @@ class Tally extends Joiner {
   }
 
   static default () {
-    return Tally.deviationAndAverage()
+    return Tally.deviationAndMean()
   }
 
-  static deviationAndAverage (deviation = 2.5) {
-    return super.deviationAndAverage(deviation)
+  static deviationAndMean (deviation = 2.5) {
+    return super.deviationAndMean(deviation)
   }
 
   static deviationAndMedian (deviation = 2.5) {


### PR DESCRIPTION
# Usage

## Standard deviation and average

All these lines are now equivalent:
```js

const aggregator = Witnet.Aggregator.default()
const aggregator = Witnet.Aggregator.default
const aggregator = Witnet.Aggregator.deviationAndMean()
const aggregator = Witnet.Aggregator.deviationAndMean
const aggregator = Witnet.Aggregator.deviationAndMean(1.5)
const aggregator = new Witnet.Aggregator({
  filters: [
    [ Witnet.Types.FILTERS.deviationStandard, 1.5 ],
  ],
  reducer: Witnet.Types.REDUCERS.averageMean,
})
```

This is also possible for Tally, with dev = 2.5 instead of 1.5
```js
const tally = Witnet.Tally.default()
const tally = Witnet.Tally.default
const tally = Witnet.Tally.deviationAndAverage()
const tally = Witnet.Tally.deviationAndAverage
const tally = Witnet.Tally.deviationAndAverage(2.5)
const tally = new Witnet.Tally({
  filters: [
    [ Witnet.Types.FILTERS.deviationStandard, 2.5 ],
  ],
  reducer: Witnet.Types.REDUCERS.averageMean,
})
```

## Standard deviation and median
These are equivalent too:
```js
const aggregator = Witnet.Aggregator.deviationAndMedian()
const aggregator = Witnet.Aggregator.deviationAndMedian
const aggregator = Witnet.Aggregator.deviationAndMedian(1.5)
const aggregator = new Witnet.Aggregator({
  filters: [
    [ Witnet.Types.FILTERS.deviationStandard, 1.5 ],
  ],
  reducer: Witnet.Types.REDUCERS.averageMedian,
})
```

## Mode
These are the same too:
```js
const aggregator = Witnet.Aggregator.mode()
const aggregator = Witnet.Aggregator.mode
const aggregator = new Witnet.Aggregator({
  filters: [
    Witnet.Types.FILTERS.mode,
  ],
  reducer: Witnet.Types.REDUCERS.mode,
})
const aggregator = new Witnet.Aggregator({
  filters: [
    [ Witnet.Types.FILTERS.mode ],
  ],
  reducer: Witnet.Types.REDUCERS.mode,
})
```
fix #67