### PR TITLE
feat(radon): sanitize GraphQL queries to achieve cheaper requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/preset-env": "^7.15.0",
         "cbor": "^8.0.0",
         "core-js": "^3.16.2",
+        "graphql-query-compress": "^1.2.4",
         "protocol-buffers": "^4.1.0",
         "regenerator-runtime": "^0.13.9",
         "request": "^2.88.2",
@@ -3663,6 +3664,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/graphql-query-compress": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/graphql-query-compress/-/graphql-query-compress-1.2.4.tgz",
+      "integrity": "sha512-W5SMy8/2RAsC9uMOV9VTwnUkp+8N3BZz6qef6jRCIxOVrVxRBiX2btvpaKrEnPU4nchnc1bCfmMDkEtCRzJUiw==",
+      "dependencies": {
+        "tokenizr": "1.5.7"
+      }
+    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -6785,6 +6794,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tokenizr": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/tokenizr/-/tokenizr-1.5.7.tgz",
+      "integrity": "sha512-w6qS6F5PNtY30DxoRD4a7nC7zOlPM2SlpQ4zLhOmqBaB1VCZrlV82bLpc/lKNOdNmrwIwcsJLDcjEJ8f7UG6Mg=="
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -9756,6 +9770,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "graphql-query-compress": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/graphql-query-compress/-/graphql-query-compress-1.2.4.tgz",
+      "integrity": "sha512-W5SMy8/2RAsC9uMOV9VTwnUkp+8N3BZz6qef6jRCIxOVrVxRBiX2btvpaKrEnPU4nchnc1bCfmMDkEtCRzJUiw==",
+      "requires": {
+        "tokenizr": "1.5.7"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -12080,6 +12102,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "tokenizr": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/tokenizr/-/tokenizr-1.5.7.tgz",
+      "integrity": "sha512-w6qS6F5PNtY30DxoRD4a7nC7zOlPM2SlpQ4zLhOmqBaB1VCZrlV82bLpc/lKNOdNmrwIwcsJLDcjEJ8f7UG6Mg=="
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.15.0",
     "cbor": "^8.0.0",
     "core-js": "^3.16.2",
+    "graphql-query-compress": "^1.2.4",
     "protocol-buffers": "^4.1.0",
     "regenerator-runtime": "^0.13.9",
     "request": "^2.88.2",

--- a/src/lib/radon/stages.js
+++ b/src/lib/radon/stages.js
@@ -1,6 +1,7 @@
 import * as CBOR from "cbor";
 import { Script } from "./script";
 import { FILTERS, REDUCERS, RETRIEVAL_METHODS, TYPES } from "./types";
+import { graphQlSanitize } from "../../utils";
 
 class Source extends Script {
   constructor(kind, firstType) {
@@ -27,7 +28,8 @@ class HttpPostSource extends Source {
 }
 
 class GraphQLSource extends HttpPostSource {
-  constructor (url, query, headers) {
+  constructor (url, rawQuery, headers) {
+    const query = graphQlSanitize(rawQuery);
     super(url, JSON.stringify({ query }), headers);
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import graphQlCompress from "graphql-query-compress"
+
 function matchAll (regex, string) {
   const matches = [];
   while (true) {
@@ -21,7 +23,7 @@ function formatPath (path) {
 }
 
 function graphQlSanitize (query) {
-  return query.replace(/[\r\n\s\t]/g, "")
+  return graphQlCompress(query)
 }
 
 function isRoutedQuery (query) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,10 @@ function formatPath (path) {
   }
 }
 
+function graphQlSanitize (query) {
+  return query.replace(/[\r\n\s\t]/g, "")
+}
+
 function isRoutedQuery (query) {
   return query.hasOwnProperty('bytecode')
 }
@@ -62,6 +66,7 @@ export {
   matchAll,
   Disabled,
   formatPath,
+  graphQlSanitize,
   isRoutedQuery,
   processArgv,
   simplifyName,

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -2,8 +2,8 @@ import {graphQlSanitize, sortObjectKeys} from '../src/utils'
 
 describe('utils', () => {
   describe('graphQlSanitize', () => {
-    const input = "{\n      pair\t (id: \"0x81e11a9374033d11cc7e7485a7192ae37d0795d6\") {\n        token1Price\r      }"
-    const expected = "{pair(id:\"0x81e11a9374033d11cc7e7485a7192ae37d0795d6\"){token1Price}"
+    const input = "{\n      pair\t (id: \"0x81e11a9374033d11cc7e7485a7192ae37d0795d6\") {\n        token1Price\rtoken2Price      }"
+    const expected = "{pair(id:\"0x81e11a9374033d11cc7e7485a7192ae37d0795d6\"){token1Price token2Price}"
     const result = graphQlSanitize(input)
 
     expect(result).toStrictEqual(expected)

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -1,6 +1,14 @@
-import { sortObjectKeys } from '../src/utils'
+import {graphQlSanitize, sortObjectKeys} from '../src/utils'
 
 describe('utils', () => {
+  describe('graphQlSanitize', () => {
+    const input = "{\n      pair\t (id: \"0x81e11a9374033d11cc7e7485a7192ae37d0795d6\") {\n        token1Price\r      }"
+    const expected = "{pair(id:\"0x81e11a9374033d11cc7e7485a7192ae37d0795d6\"){token1Price}"
+    const result = graphQlSanitize(input)
+
+    expect(result).toStrictEqual(expected)
+  })
+
   describe('sortObjectKeys', () => {
     it('sort the keys of an object', () => {
       const obj = { b: 'b', c: 'c', a: 'a' }


### PR DESCRIPTION
Upon creating a GraphQL data source, this will remove all unnecessary whitespace from the GraphQL query string so as to produce more compact Witnet queries, which should in turn result in cheaper requests.

fix #75